### PR TITLE
Adding a counter for API calls

### DIFF
--- a/lib/remotes/github.js
+++ b/lib/remotes/github.js
@@ -253,8 +253,12 @@ function errorBadCredentials(res) {
 /**
  * The API_COUNTER variable will be printed on process exit, to allow devs to get an idea of how many requests they
  * are making when enabling debug mode
+ *
+ * Notice, it also uses a distinct debug namespace
  */
 
-process.on("exit", function () {
-  debug("api calls made %d", API_COUNTER);
+var apiDebug = require('debug')('remotes:github:api')
+
+process.on('exit', function () {
+  apiDebug('used %d', API_COUNTER);
 });


### PR DESCRIPTION
I know github rate-limiting is going to come up for me since our team uses CI, so I thought adding a counter here would be helpful. (so I can see easily if any changes I make have a good effect on the overall count)

A couple of caveats:
- this only counts github API calls made within this file directly (I noticed that the archive function only returns a string, so it won't count stuff like that)
- this does not include retries, redirects, etc that may inflate the actual count github has

If this isn't going to be accurate enough to prove useful, I'm open to other ideas.
